### PR TITLE
1.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ endif (APPLE)
 
 set (PROJECT_NAME "AirDC++ Web Client")
 set (TAG_APPLICATION "AirDC++w")
-set (VERSION "1.0.1")
-set (SOVERSION "1.0.1" )
+set (VERSION "1.0.2")
+set (SOVERSION "1.0.2" )
 
 set (GNUCXX_MINIMUM_VERSION "4.8")
 

--- a/airdcpp-core/airdcpp/Bundle.h
+++ b/airdcpp-core/airdcpp/Bundle.h
@@ -157,7 +157,6 @@ public:
 	IGETSET(time_t, bundleDate, BundleDate, 0);				// the file/directory modify date picked from the remote filelist when the bundle has been queued
 	IGETSET(uint64_t, start, Start, 0);						// time that is being reset every time when a waiting the bundle gets running downloads
 	IGETSET(time_t, lastSearch, LastSearch, 0);				// last time when the bundle was searched for
-	IGETSET(bool, simpleMatching, SimpleMatching, true);	// the directory structure is simple enough for matching partial lists with subdirs cut from the path
 	IGETSET(bool, seqOrder, SeqOrder, false);				// using an alphabetical downloading order for files (not enabled by default for fresh bundles)
 
 	IGETSET(bool, singleUser, SingleUser, true);		// the bundle is downloaded from a single user (may have multiple connections)

--- a/airdcpp-core/airdcpp/BundleQueue.cpp
+++ b/airdcpp-core/airdcpp/BundleQueue.cpp
@@ -50,7 +50,6 @@ void BundleQueue::addBundle(BundlePtr& aBundle) noexcept {
 	aBundle->setStatus(Bundle::STATUS_QUEUED);
 	aBundle->setDownloadedBytes(0); //sets to downloaded segments
 
-	updateSearchMode(aBundle);
 	addSearchPrio(aBundle);
 }
 
@@ -224,20 +223,6 @@ void BundleQueue::getSearchItems(const BundlePtr& aBundle, map<string, QueueItem
 			searchItems_.emplace(dir, searchItem);
 		}
 	}
-}
-
-void BundleQueue::updateSearchMode(const BundlePtr& aBundle) const noexcept {
-	auto paths = bundlePaths.find(aBundle);
-	if (paths == bundlePaths.end()) {
-		return;
-	}
-
-	StringSet mainDirectories;
-	for (const auto& i : paths->second) {
-		mainDirectories.insert(AirUtil::getReleaseDir(i->path, false));
-	}
-
-	aBundle->setSimpleMatching(mainDirectories.size() <= 4);
 }
 
 void BundleQueue::removePathInfo(const PathInfo* aPathInfo) noexcept {

--- a/airdcpp-core/airdcpp/BundleQueue.h
+++ b/airdcpp-core/airdcpp/BundleQueue.h
@@ -71,7 +71,6 @@ public:
 
 	void saveQueue(bool force) noexcept;
 	void getSearchItems(const BundlePtr& aBundle, map<string, QueueItemPtr>& searchItems_, bool aManualSearch) const noexcept;
-	void updateSearchMode(const BundlePtr& aBundle) const noexcept;
 
 	DupeType isDirQueued(const string& aPath, int64_t aSize) const noexcept;
 	StringList getDirPaths(const string& aPath) const noexcept;

--- a/airdcpp-core/airdcpp/StringTokenizer.h
+++ b/airdcpp-core/airdcpp/StringTokenizer.h
@@ -40,8 +40,9 @@ private:
 			j = i + aSeparatorLength;
 		}
 
-		if (j < aString.size())
+		if (j < aString.size() || (aAllowEmptyTokens && j == aString.size())) {
 			tokens.push_back(aString.substr(j, aString.size() - j));
+		}
 	}
 public:
 	StringTokenizer(const T& aString, const typename T::value_type& aToken, bool aAllowEmptyTokens = false) : 

--- a/airdcpp-webapi/web-server/FileServer.h
+++ b/airdcpp-webapi/web-server/FileServer.h
@@ -43,6 +43,13 @@ namespace webserver {
 		string parseViewFilePath(const string& aResource) const;
 
 		static string getExtension(const string& aResource) noexcept;
+
+		// Parses start and end position from a range HTTP request field
+		// Initial value of end_ should be the file size
+		// Returns true if the partial range was parsed successfully
+		static bool parsePartialRange(const string& aHeaderData, int64_t& start_, int64_t& end_) noexcept;
+
+		static string formatPartialRange(int64_t aStart, int64_t aEnd, int64_t aFileSize) noexcept;
 	};
 }
 


### PR DESCRIPTION
**Web Client 1.0.2**

- Add support for partial HTTP transfers: allows seeking in media files, fixes viewing of videos in Safari, fixes replays in other browsers
- Installation: fixes availibility of python command not being checked correctly (@sbraz, gentoo/gentoo#1124)

**Web UI 1.0.3**

- Fix web user removal
- Allow viewing videos in full screen mode with Google Chrome
- Don't send the HTTP referer header when clicking on external links (third party sites won't receive the client URL)