### PR TITLE
Making sure web-server.json is always written to file on --configure wizard

### DIFF
--- a/airdcppd/ConfigPrompt.cpp
+++ b/airdcppd/ConfigPrompt.cpp
@@ -104,6 +104,9 @@ bool ConfigPrompt::runConfigure(webserver::WebServerManager* wsm) {
 		std::cout << toBold("No valid configuration was entered. Please re-run the command.") << std::endl;
 		return false;
 	} else {
+		// Set the dirty flag, otherwise we wont save web-server.json
+		wsm->setDirty();
+
 		std::cout << toBold("Configuration finished")
 			<< std::endl
 			<< std::endl


### PR DESCRIPTION
When a user runs the `--configure` wizard we are effectively mutating the `WebServerManager::plainServerConfig` and `WebServerManager::tlsServerConfig` fields. So the `WebServerManager::isDirty` flag was never set, and no file was written.